### PR TITLE
Use only 2 workers in Spark by default

### DIFF
--- a/03_link_datasets.ipynb
+++ b/03_link_datasets.ipynb
@@ -151,7 +151,7 @@
     "splink_engine = \"duckdb\"\n",
     "# Only matter if using Spark\n",
     "spark_local = False\n",
-    "spark_num_workers = 15\n",
+    "spark_num_workers = 2\n",
     "spark_memory_per_worker = \"4GB\"\n",
     "spark_memory_master = \"10GB\"\n",
     "# Only matter if using distributed (non-local) Spark\n",


### PR DESCRIPTION
This is not incredibly scientific, but 15 workers was failing on my laptop. I think we want to set the defaults so the quickstart goes as smooth as possible.